### PR TITLE
feat(api): add TrainingPlanController with 4 REST endpoints

### DIFF
--- a/src/main/java/com/wellness/ritmo/api/controller/TrainingPlanController.java
+++ b/src/main/java/com/wellness/ritmo/api/controller/TrainingPlanController.java
@@ -1,0 +1,78 @@
+package com.wellness.ritmo.api.controller;
+
+import com.wellness.ritmo.api.dto.GeneratePlanRequest;
+import com.wellness.ritmo.api.dto.TrainingPlanResponse;
+import com.wellness.ritmo.api.dto.TrainingSessionResponse;
+import com.wellness.ritmo.api.dto.mapper.TrainingPlanMapper;
+import com.wellness.ritmo.domain.model.TrainingPlan;
+import com.wellness.ritmo.domain.model.TrainingSession;
+import com.wellness.ritmo.domain.service.TrainingPlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/{userId}/training-plans")
+@RequiredArgsConstructor
+@Tag(name = "Training Plans", description = "Gerenciamento de planos de treino")
+public class TrainingPlanController {
+
+    private final TrainingPlanService trainingPlanService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Gera um plano de treino para o usuário")
+    @ApiResponse(responseCode = "201", description = "Plano criado com sucesso")
+    @ApiResponse(responseCode = "404", description = "Goal ou perfil não encontrado para o usuário")
+    @ApiResponse(responseCode = "409", description = "Já existe um plano ativo para este usuário")
+    public TrainingPlanResponse generate(
+            @PathVariable Long userId,
+            @Valid @RequestBody GeneratePlanRequest request
+    ) {
+        TrainingPlan plan = trainingPlanService.generatePlan(userId, request.goalId());
+        return TrainingPlanMapper.toResponse(plan);
+    }
+
+    @GetMapping("/current")
+    @Operation(summary = "Retorna o plano ativo da semana atual")
+    @ApiResponse(responseCode = "200", description = "Plano ativo encontrado")
+    @ApiResponse(responseCode = "404", description = "Nenhum plano ativo encontrado para o usuário")
+    public TrainingPlanResponse current(@PathVariable Long userId) {
+        TrainingPlan plan = trainingPlanService.findCurrentPlan(userId);
+        return TrainingPlanMapper.toResponse(plan);
+    }
+
+    @GetMapping("/{planId}/sessions")
+    @Operation(summary = "Retorna as sessões de um plano de treino")
+    @ApiResponse(responseCode = "200", description = "Lista de sessões retornada com sucesso")
+    @ApiResponse(responseCode = "404", description = "Plano não encontrado ou não pertence ao usuário")
+    public List<TrainingSessionResponse> sessions(
+            @PathVariable Long userId,
+            @PathVariable Long planId
+    ) {
+        List<TrainingSession> sessions = trainingPlanService.findSessions(userId, planId);
+        return sessions.stream()
+                .map(TrainingPlanMapper::toSessionResponse)
+                .toList();
+    }
+
+    @PatchMapping("/{planId}/sessions/{sessionId}/complete")
+    @Operation(summary = "Marca uma sessão como concluída")
+    @ApiResponse(responseCode = "200", description = "Sessão marcada como concluída")
+    @ApiResponse(responseCode = "404", description = "Sessão não encontrada ou não pertence ao plano/usuário")
+    @ApiResponse(responseCode = "409", description = "Sessão já está concluída")
+    public TrainingSessionResponse completeSession(
+            @PathVariable Long userId,
+            @PathVariable Long planId,
+            @PathVariable Long sessionId
+    ) {
+        TrainingSession session = trainingPlanService.completeSession(userId, planId, sessionId);
+        return TrainingPlanMapper.toSessionResponse(session);
+    }
+}

--- a/src/main/java/com/wellness/ritmo/api/dto/GeneratePlanRequest.java
+++ b/src/main/java/com/wellness/ritmo/api/dto/GeneratePlanRequest.java
@@ -1,0 +1,8 @@
+package com.wellness.ritmo.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record GeneratePlanRequest(
+        @NotNull(message = "goalId é obrigatório")
+        Long goalId
+) {}

--- a/src/main/java/com/wellness/ritmo/api/dto/TrainingPlanResponse.java
+++ b/src/main/java/com/wellness/ritmo/api/dto/TrainingPlanResponse.java
@@ -1,0 +1,15 @@
+package com.wellness.ritmo.api.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TrainingPlanResponse(
+        Long id,
+        Long userId,
+        Long goalId,
+        Boolean active,
+        LocalDate weekStart,
+        LocalDateTime createdAt,
+        List<TrainingSessionResponse> sessions
+) {}

--- a/src/main/java/com/wellness/ritmo/api/dto/TrainingSessionResponse.java
+++ b/src/main/java/com/wellness/ritmo/api/dto/TrainingSessionResponse.java
@@ -1,0 +1,16 @@
+package com.wellness.ritmo.api.dto;
+
+import com.wellness.ritmo.domain.model.Enum.SessionStatus;
+import com.wellness.ritmo.domain.model.Enum.SessionType;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+public record TrainingSessionResponse(
+        Long id,
+        SessionType sessionType,
+        Integer targetPaceSec,
+        DayOfWeek dayOfWeek,
+        SessionStatus status,
+        LocalDateTime completedAt
+) {}

--- a/src/main/java/com/wellness/ritmo/api/dto/mapper/TrainingPlanMapper.java
+++ b/src/main/java/com/wellness/ritmo/api/dto/mapper/TrainingPlanMapper.java
@@ -1,0 +1,40 @@
+package com.wellness.ritmo.api.dto.mapper;
+
+import com.wellness.ritmo.api.dto.TrainingPlanResponse;
+import com.wellness.ritmo.api.dto.TrainingSessionResponse;
+import com.wellness.ritmo.domain.model.TrainingPlan;
+import com.wellness.ritmo.domain.model.TrainingSession;
+
+import java.util.List;
+
+public class TrainingPlanMapper {
+
+    private TrainingPlanMapper() {}
+
+    public static TrainingPlanResponse toResponse(TrainingPlan plan) {
+        List<TrainingSessionResponse> sessions = plan.getSessions().stream()
+                .map(TrainingPlanMapper::toSessionResponse)
+                .toList();
+
+        return new TrainingPlanResponse(
+                plan.getId(),
+                plan.getUser().getId(),
+                plan.getGoal().getId(),
+                plan.getActive(),
+                plan.getWeekStart(),
+                plan.getCreatedAt(),
+                sessions
+        );
+    }
+
+    public static TrainingSessionResponse toSessionResponse(TrainingSession session) {
+        return new TrainingSessionResponse(
+                session.getId(),
+                session.getSessionType(),
+                session.getTargetPaceSec(),
+                session.getDayOfWeek(),
+                session.getStatus(),
+                session.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/wellness/ritmo/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wellness/ritmo/api/exception/GlobalExceptionHandler.java
@@ -67,6 +67,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponseDto> handleConflict(IllegalStateException ex) {
+        var response = new ErrorResponseDto(
+                HttpStatus.CONFLICT.value(),
+                ex.getMessage() != null ? ex.getMessage() : "Conflito de estado"
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleGeneralExceptions(Exception ex) {
         logger.error("Erro não tratado capturado pelo GlobalExceptionHandler", ex);

--- a/src/main/java/com/wellness/ritmo/domain/model/Enum/SessionStatus.java
+++ b/src/main/java/com/wellness/ritmo/domain/model/Enum/SessionStatus.java
@@ -1,0 +1,6 @@
+package com.wellness.ritmo.domain.model.Enum;
+
+public enum SessionStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/com/wellness/ritmo/domain/model/TrainingPlan.java
+++ b/src/main/java/com/wellness/ritmo/domain/model/TrainingPlan.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +46,12 @@ public class TrainingPlan {
             fetch = FetchType.LAZY
     )
     private List<TrainingSession> sessions = new ArrayList<>();
+
+    @Column(name = "active", nullable = false)
+    private Boolean active = true;
+
+    @Column(name = "week_start", nullable = false)
+    private LocalDate weekStart;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/wellness/ritmo/domain/model/TrainingSession.java
+++ b/src/main/java/com/wellness/ritmo/domain/model/TrainingSession.java
@@ -1,5 +1,6 @@
 package com.wellness.ritmo.domain.model;
 
+import com.wellness.ritmo.domain.model.Enum.SessionStatus;
 import com.wellness.ritmo.domain.model.Enum.SessionType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -39,4 +41,11 @@ public class TrainingSession {
     @Enumerated(EnumType.STRING)
     @Column(name = "day_of_week", nullable = false, length = 15)
     private DayOfWeek dayOfWeek;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SessionStatus status = SessionStatus.PENDING;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
 }

--- a/src/main/java/com/wellness/ritmo/domain/repository/TrainingPlanRepository.java
+++ b/src/main/java/com/wellness/ritmo/domain/repository/TrainingPlanRepository.java
@@ -3,5 +3,14 @@ package com.wellness.ritmo.domain.repository;
 import com.wellness.ritmo.domain.model.TrainingPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface TrainingPlanRepository extends JpaRepository<TrainingPlan, Long> {
+
+    boolean existsByUserIdAndActiveTrue(Long userId);
+
+    Optional<TrainingPlan> findByUserIdAndActiveTrueAndWeekStart(Long userId, LocalDate weekStart);
+
+    Optional<TrainingPlan> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/wellness/ritmo/domain/repository/TrainingSessionRepository.java
+++ b/src/main/java/com/wellness/ritmo/domain/repository/TrainingSessionRepository.java
@@ -1,0 +1,14 @@
+package com.wellness.ritmo.domain.repository;
+
+import com.wellness.ritmo.domain.model.TrainingSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TrainingSessionRepository extends JpaRepository<TrainingSession, Long> {
+
+    List<TrainingSession> findByTrainingPlanId(Long trainingPlanId);
+
+    Optional<TrainingSession> findByIdAndTrainingPlanIdAndTrainingPlanUserId(Long id, Long planId, Long userId);
+}

--- a/src/main/java/com/wellness/ritmo/domain/service/TrainingPlanService.java
+++ b/src/main/java/com/wellness/ritmo/domain/service/TrainingPlanService.java
@@ -2,9 +2,11 @@ package com.wellness.ritmo.domain.service;
 
 import com.wellness.ritmo.domain.model.*;
 import com.wellness.ritmo.domain.model.Enum.GoalStatus;
+import com.wellness.ritmo.domain.model.Enum.SessionStatus;
 import com.wellness.ritmo.domain.model.Enum.SessionType;
 import com.wellness.ritmo.domain.repository.GoalRepository;
 import com.wellness.ritmo.domain.repository.TrainingPlanRepository;
+import com.wellness.ritmo.domain.repository.TrainingSessionRepository;
 import com.wellness.ritmo.domain.repository.UserAvailabilityRepository;
 import com.wellness.ritmo.domain.repository.UserProfileRepository;
 import com.wellness.ritmo.domain.service.strategy.PaceCalculationStrategy;
@@ -14,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -29,6 +33,7 @@ public class TrainingPlanService {
     private final UserAvailabilityRepository userAvailabilityRepository;
     private final UserProfileRepository userProfileRepository;
     private final TrainingPlanRepository trainingPlanRepository;
+    private final TrainingSessionRepository trainingSessionRepository;
     private final Map<SessionType, PaceCalculationStrategy> paceStrategies;
 
     public TrainingPlanService(
@@ -36,11 +41,13 @@ public class TrainingPlanService {
             UserAvailabilityRepository userAvailabilityRepository,
             UserProfileRepository userProfileRepository,
             TrainingPlanRepository trainingPlanRepository,
+            TrainingSessionRepository trainingSessionRepository,
             List<PaceCalculationStrategy> strategies) {
         this.goalRepository = goalRepository;
         this.userAvailabilityRepository = userAvailabilityRepository;
         this.userProfileRepository = userProfileRepository;
         this.trainingPlanRepository = trainingPlanRepository;
+        this.trainingSessionRepository = trainingSessionRepository;
         this.paceStrategies = strategies.stream()
                 .collect(Collectors.toMap(PaceCalculationStrategy::supports, Function.identity()));
     }
@@ -48,6 +55,10 @@ public class TrainingPlanService {
     @Transactional
     public TrainingPlan generatePlan(Long userId, Long goalId) {
         log.info("Iniciando geração de plano para userId={} goalId={}", userId, goalId);
+
+        if (trainingPlanRepository.existsByUserIdAndActiveTrue(userId)) {
+            throw new IllegalStateException("Usuário " + userId + " já possui um plano ativo");
+        }
 
         Goal goal = goalRepository.findByIdAndUserIdAndStatus(goalId, userId, GoalStatus.OPEN)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -76,6 +87,8 @@ public class TrainingPlanService {
         TrainingPlan plan = new TrainingPlan();
         plan.setUser(user);
         plan.setGoal(goal);
+        plan.setActive(true);
+        plan.setWeekStart(LocalDate.now().with(DayOfWeek.MONDAY));
 
         List<TrainingSession> sessions = new ArrayList<>();
         for (DayOfWeek day : selectedDays) {
@@ -104,6 +117,38 @@ public class TrainingPlanService {
                 userId, goalId, sessions.size());
 
         return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public TrainingPlan findCurrentPlan(Long userId) {
+        LocalDate weekStart = LocalDate.now().with(DayOfWeek.MONDAY);
+        return trainingPlanRepository.findByUserIdAndActiveTrueAndWeekStart(userId, weekStart)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Nenhum plano ativo encontrado para o usuário " + userId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<TrainingSession> findSessions(Long userId, Long planId) {
+        TrainingPlan plan = trainingPlanRepository.findByIdAndUserId(planId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Plano " + planId + " não encontrado para o usuário " + userId));
+        return plan.getSessions();
+    }
+
+    @Transactional
+    public TrainingSession completeSession(Long userId, Long planId, Long sessionId) {
+        TrainingSession session = trainingSessionRepository
+                .findByIdAndTrainingPlanIdAndTrainingPlanUserId(sessionId, planId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Sessão " + sessionId + " não encontrada para o plano " + planId + " do usuário " + userId));
+
+        if (session.getStatus() == SessionStatus.COMPLETED) {
+            throw new IllegalStateException("Sessão " + sessionId + " já está concluída");
+        }
+
+        session.setStatus(SessionStatus.COMPLETED);
+        session.setCompletedAt(LocalDateTime.now());
+        return trainingSessionRepository.save(session);
     }
 
     List<DayOfWeek> selectDays(List<UserAvailability> availabilities, int weeklyFrequency) {

--- a/src/test/java/com/wellness/ritmo/api/controller/TrainingPlanControllerTest.java
+++ b/src/test/java/com/wellness/ritmo/api/controller/TrainingPlanControllerTest.java
@@ -1,0 +1,232 @@
+package com.wellness.ritmo.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wellness.ritmo.api.dto.GeneratePlanRequest;
+import com.wellness.ritmo.api.exception.GlobalExceptionHandler;
+import com.wellness.ritmo.domain.model.*;
+import com.wellness.ritmo.domain.model.Enum.GoalStatus;
+import com.wellness.ritmo.domain.model.Enum.GoalType;
+import com.wellness.ritmo.domain.model.Enum.SessionStatus;
+import com.wellness.ritmo.domain.model.Enum.SessionType;
+import com.wellness.ritmo.domain.service.TrainingPlanService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = TrainingPlanController.class)
+@Import(GlobalExceptionHandler.class)
+class TrainingPlanControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TrainingPlanService trainingPlanService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long GOAL_ID = 10L;
+    private static final Long PLAN_ID = 100L;
+    private static final Long SESSION_ID = 200L;
+    private static final String BASE_URL = "/api/v1/users/{userId}/training-plans";
+
+    private TrainingPlan plan;
+    private TrainingSession session;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        user.setId(USER_ID);
+
+        Goal goal = new Goal();
+        goal.setId(GOAL_ID);
+        goal.setUser(user);
+        goal.setGoalType(GoalType.PACE);
+        goal.setStatus(GoalStatus.OPEN);
+        goal.setWeeklyFrequency(3);
+
+        plan = new TrainingPlan();
+        plan.setId(PLAN_ID);
+        plan.setUser(user);
+        plan.setGoal(goal);
+        plan.setActive(true);
+        plan.setWeekStart(LocalDate.now().with(DayOfWeek.MONDAY));
+        plan.setCreatedAt(LocalDateTime.now());
+
+        session = new TrainingSession();
+        session.setId(SESSION_ID);
+        session.setTrainingPlan(plan);
+        session.setSessionType(SessionType.EASY);
+        session.setTargetPaceSec(360);
+        session.setDayOfWeek(DayOfWeek.TUESDAY);
+        session.setStatus(SessionStatus.PENDING);
+
+        TrainingSession session2 = new TrainingSession();
+        session2.setId(201L);
+        session2.setTrainingPlan(plan);
+        session2.setSessionType(SessionType.LONG_RUN);
+        session2.setTargetPaceSec(330);
+        session2.setDayOfWeek(DayOfWeek.SATURDAY);
+        session2.setStatus(SessionStatus.PENDING);
+
+        TrainingSession session3 = new TrainingSession();
+        session3.setId(202L);
+        session3.setTrainingPlan(plan);
+        session3.setSessionType(SessionType.INTERVALS);
+        session3.setTargetPaceSec(270);
+        session3.setDayOfWeek(DayOfWeek.THURSDAY);
+        session3.setStatus(SessionStatus.PENDING);
+
+        plan.setSessions(List.of(session, session2, session3));
+    }
+
+    @Test
+    @DisplayName("POST - 201: Gera plano com sucesso")
+    void shouldReturn201WhenPlanGenerated() throws Exception {
+        when(trainingPlanService.generatePlan(USER_ID, GOAL_ID)).thenReturn(plan);
+
+        mockMvc.perform(post(BASE_URL, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GeneratePlanRequest(GOAL_ID))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(PLAN_ID))
+                .andExpect(jsonPath("$.userId").value(USER_ID))
+                .andExpect(jsonPath("$.goalId").value(GOAL_ID))
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.sessions", hasSize(3)));
+
+        verify(trainingPlanService).generatePlan(USER_ID, GOAL_ID);
+    }
+
+    @Test
+    @DisplayName("POST - 409: Já existe plano ativo")
+    void shouldReturn409WhenActivePlanExists() throws Exception {
+        when(trainingPlanService.generatePlan(USER_ID, GOAL_ID))
+                .thenThrow(new IllegalStateException("Usuário " + USER_ID + " já possui um plano ativo"));
+
+        mockMvc.perform(post(BASE_URL, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GeneratePlanRequest(GOAL_ID))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("Usuário " + USER_ID + " já possui um plano ativo"));
+    }
+
+    @Test
+    @DisplayName("POST - 404: Goal não encontrado")
+    void shouldReturn404WhenGoalNotFound() throws Exception {
+        when(trainingPlanService.generatePlan(USER_ID, GOAL_ID))
+                .thenThrow(new EntityNotFoundException("Goal " + GOAL_ID + " não encontrado para o usuário " + USER_ID));
+
+        mockMvc.perform(post(BASE_URL, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GeneratePlanRequest(GOAL_ID))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Goal " + GOAL_ID + " não encontrado para o usuário " + USER_ID));
+    }
+
+    @Test
+    @DisplayName("GET /current - 200: Retorna plano ativo")
+    void shouldReturn200WhenCurrentPlanFound() throws Exception {
+        when(trainingPlanService.findCurrentPlan(USER_ID)).thenReturn(plan);
+
+        mockMvc.perform(get(BASE_URL + "/current", USER_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(PLAN_ID))
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.sessions", hasSize(3)));
+    }
+
+    @Test
+    @DisplayName("GET /current - 404: Nenhum plano ativo")
+    void shouldReturn404WhenNoCurrentPlan() throws Exception {
+        when(trainingPlanService.findCurrentPlan(USER_ID))
+                .thenThrow(new EntityNotFoundException("Nenhum plano ativo encontrado para o usuário " + USER_ID));
+
+        mockMvc.perform(get(BASE_URL + "/current", USER_ID))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Nenhum plano ativo encontrado para o usuário " + USER_ID));
+    }
+
+    @Test
+    @DisplayName("GET /{planId}/sessions - 200: Retorna sessões do plano")
+    void shouldReturn200WithSessions() throws Exception {
+        when(trainingPlanService.findSessions(USER_ID, PLAN_ID)).thenReturn(plan.getSessions());
+
+        mockMvc.perform(get(BASE_URL + "/{planId}/sessions", USER_ID, PLAN_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].sessionType").exists())
+                .andExpect(jsonPath("$[0].targetPaceSec").exists());
+    }
+
+    @Test
+    @DisplayName("GET /{planId}/sessions - 404: Plano não encontrado")
+    void shouldReturn404WhenPlanNotFound() throws Exception {
+        when(trainingPlanService.findSessions(USER_ID, PLAN_ID))
+                .thenThrow(new EntityNotFoundException("Plano " + PLAN_ID + " não encontrado para o usuário " + USER_ID));
+
+        mockMvc.perform(get(BASE_URL + "/{planId}/sessions", USER_ID, PLAN_ID))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("PATCH complete - 200: Sessão marcada como concluída")
+    void shouldReturn200WhenSessionCompleted() throws Exception {
+        session.setStatus(SessionStatus.COMPLETED);
+        session.setCompletedAt(LocalDateTime.now());
+        when(trainingPlanService.completeSession(USER_ID, PLAN_ID, SESSION_ID)).thenReturn(session);
+
+        mockMvc.perform(patch(BASE_URL + "/{planId}/sessions/{sessionId}/complete", USER_ID, PLAN_ID, SESSION_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(SESSION_ID))
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.completedAt").exists());
+    }
+
+    @Test
+    @DisplayName("PATCH complete - 404: Sessão não encontrada")
+    void shouldReturn404WhenSessionNotFound() throws Exception {
+        when(trainingPlanService.completeSession(USER_ID, PLAN_ID, SESSION_ID))
+                .thenThrow(new EntityNotFoundException(
+                        "Sessão " + SESSION_ID + " não encontrada para o plano " + PLAN_ID + " do usuário " + USER_ID));
+
+        mockMvc.perform(patch(BASE_URL + "/{planId}/sessions/{sessionId}/complete", USER_ID, PLAN_ID, SESSION_ID))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("PATCH complete - 409: Sessão já concluída")
+    void shouldReturn409WhenSessionAlreadyCompleted() throws Exception {
+        when(trainingPlanService.completeSession(USER_ID, PLAN_ID, SESSION_ID))
+                .thenThrow(new IllegalStateException("Sessão " + SESSION_ID + " já está concluída"));
+
+        mockMvc.perform(patch(BASE_URL + "/{planId}/sessions/{sessionId}/complete", USER_ID, PLAN_ID, SESSION_ID))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("Sessão " + SESSION_ID + " já está concluída"));
+    }
+}

--- a/src/test/java/com/wellness/ritmo/domain/service/TrainingPlanServiceTest.java
+++ b/src/test/java/com/wellness/ritmo/domain/service/TrainingPlanServiceTest.java
@@ -6,6 +6,7 @@ import com.wellness.ritmo.domain.model.Enum.GoalType;
 import com.wellness.ritmo.domain.model.Enum.SessionType;
 import com.wellness.ritmo.domain.repository.GoalRepository;
 import com.wellness.ritmo.domain.repository.TrainingPlanRepository;
+import com.wellness.ritmo.domain.repository.TrainingSessionRepository;
 import com.wellness.ritmo.domain.repository.UserAvailabilityRepository;
 import com.wellness.ritmo.domain.repository.UserProfileRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -36,6 +37,7 @@ class TrainingPlanServiceTest {
     @Mock private UserAvailabilityRepository userAvailabilityRepository;
     @Mock private UserProfileRepository userProfileRepository;
     @Mock private TrainingPlanRepository trainingPlanRepository;
+    @Mock private TrainingSessionRepository trainingSessionRepository;
 
     private TrainingPlanService trainingPlanService;
 
@@ -54,6 +56,7 @@ class TrainingPlanServiceTest {
             userAvailabilityRepository,
             userProfileRepository,
             trainingPlanRepository,
+            trainingSessionRepository,
             List.of(
                 new EasyPaceStrategy(),
                 new IntervalsPaceStrategy(),


### PR DESCRIPTION
- POST   /training-plans → generate plan (201, 409)
- GET    /training-plans/current → active plan (200, 404)
- GET    /training-plans/{planId}/sessions → list sessions (200, 404)
- PATCH  /sessions/{sessionId}/complete → mark as done (200, 404, 409)
- Add Swagger @Operation and @ApiResponse on all endpoints
- Add @Valid on POST request body
- Add MockMvc tests covering all status codes